### PR TITLE
Make needs bash shell to enable brace expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 filename=main
+SHELL=/bin/bash
 
 all:
 	pdflatex ${filename}
@@ -11,6 +12,5 @@ fast:
 
 
 clean:
-	rm -f ${filename}.{ps,pdf,log,aux,out,dvi,bbl,blg,toc,bcf}
-	rm -f ${filename}.run.xml
+	rm -f ${filename}.{ps,pdf,log,aux,out,dvi,bbl,blg,toc,bcf,run.xml}
 	rm -rf tmp


### PR DESCRIPTION
Just added the `bash` shell specification since it hadn't worked in my computer only because Make used a `sh` shell and `make clean` didn't work as expected.